### PR TITLE
Add useShouldReloadCallback hook

### DIFF
--- a/packages/common/frame.ts
+++ b/packages/common/frame.ts
@@ -1,5 +1,10 @@
 import { Metadata } from "./metadata";
 
+export type ShouldReloadCallback = (
+  newPath: string,
+  newProps: Record<string, unknown>
+) => boolean;
+
 export interface Frame<Props = Record<string, unknown>> {
   id: number;
   path: string;
@@ -7,5 +12,5 @@ export interface Frame<Props = Record<string, unknown>> {
   view: string;
   props: Props;
   context: Record<string, unknown>;
-  shouldReloadCallback?: (newPath: string, newProps: Props) => boolean;
+  shouldReloadCallback?: ShouldReloadCallback;
 }

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -5,5 +5,5 @@ export {
   djangoGet,
   type DjangoBridgeResponse,
 } from "./fetch";
-export { type Frame } from "./frame";
+export { type ShouldReloadCallback, type Frame } from "./frame";
 export { type Metadata } from "./metadata";

--- a/packages/react/src/components/Browser.tsx
+++ b/packages/react/src/components/Browser.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode } from "react";
+import { ShouldReloadCallback } from "@common";
 import { DirtyFormContext } from "../dirtyform";
 
 import { NavigationController } from "../navigation";
@@ -60,6 +61,9 @@ function Browser({
       openOverlay,
       refreshProps,
       isNavigating,
+      setShouldReloadCallback: (callback: ShouldReloadCallback) => {
+        currentFrame.shouldReloadCallback = callback;
+      },
     }),
     [
       currentFrame,

--- a/packages/react/src/contexts.ts
+++ b/packages/react/src/contexts.ts
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Message } from "@common";
+import { Message, ShouldReloadCallback } from "@common";
 
 export interface NavigateOptions {
   pushState?: boolean;
@@ -49,6 +49,7 @@ export interface Navigation {
   ) => void;
   refreshProps: () => Promise<void>;
   isNavigating: boolean;
+  setShouldReloadCallback: (callback: ShouldReloadCallback) => void;
 }
 
 export const NavigationContext = React.createContext<Navigation>({
@@ -85,6 +86,7 @@ export const NavigationContext = React.createContext<Navigation>({
     return Promise.resolve();
   },
   isNavigating: false,
+  setShouldReloadCallback: () => {},
 });
 
 // This context is used to allow form widgets to notify their forms that data has changed

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useCallback, useContext, useEffect } from "react";
+import { ShouldReloadCallback } from "@common";
 import { NavigationContext } from "./contexts";
 
 export type Timer = ReturnType<typeof setTimeout>;
@@ -30,4 +31,17 @@ export function useAutoRefresh(enabled: boolean, interval: number) {
       }
     };
   }, [enabled, interval, refreshProps]);
+}
+
+export function useShouldReloadCallback(
+  callback: ShouldReloadCallback,
+  deps: React.DependencyList
+) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const memoisedCallback = useCallback(callback, deps);
+  const { setShouldReloadCallback } = useContext(NavigationContext);
+  useEffect(
+    () => setShouldReloadCallback(memoisedCallback),
+    [memoisedCallback, setShouldReloadCallback]
+  );
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -225,7 +225,7 @@ export {
 export type { Navigation } from "./contexts";
 export { DirtyFormContext, DirtyFormMarker } from "./dirtyform";
 export type { DirtyForm } from "./dirtyform";
-export { useAutoRefresh } from "./hooks";
+export { useAutoRefresh, useShouldReloadCallback } from "./hooks";
 export { type NavigationController } from "./navigation";
 export type { Frame, Message, DjangoBridgeResponse as Response, Metadata };
 export { Link, BuildLinkElement, buildLinkElement };


### PR DESCRIPTION
Currently on every single request, the view is reloaded (clearing all state) even if the same view is used by the next URL.

This callback allows you to control whether the reload the view or just update the props. It makes it possible to implement nice transitions when moving to a different URL with the same view.