### PR TITLE
Make it possible to use Django Bridge as a hidden dependency

### DIFF
--- a/python/django_bridge/adapters/registry.py
+++ b/python/django_bridge/adapters/registry.py
@@ -16,7 +16,6 @@ class CustomAdapterRegistry(AdapterRegistry):
 
 
 registry = CustomAdapterRegistry()
-JSContext = registry.js_context_class
 
 
 def register(adapter, cls):

--- a/python/django_bridge/conf.py
+++ b/python/django_bridge/conf.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
-from .adapters.registry import JSContext
+from .adapters.registry import registry
 
 
 class DjangoBridgeConfig:
@@ -17,6 +17,7 @@ class DjangoBridgeConfig:
         vite_devserver_url=None,
         bootstrap_template="django_bridge/bootstrap.html",
         context_providers=None,
+        adapter_registry=registry
     ):
         self.framework = framework
         self.entry_point = entry_point
@@ -24,6 +25,7 @@ class DjangoBridgeConfig:
         self.vite_devserver_url = vite_devserver_url
         self.bootstrap_template = bootstrap_template
         self.context_providers = context_providers or {}
+        self.adapter_registry = adapter_registry
 
     @classmethod
     def from_settings(cls):
@@ -50,6 +52,5 @@ class DjangoBridgeConfig:
         return config
 
     def pack(self, data):
-        # TODO: Provide a way for adapters to be registered against this class
-        js_context = JSContext()
+        js_context = self.adapter_registry.js_context_class()
         return js_context.pack(data)

--- a/python/django_bridge/conf.py
+++ b/python/django_bridge/conf.py
@@ -53,6 +53,3 @@ class DjangoBridgeConfig:
         # TODO: Provide a way for adapters to be registered against this class
         js_context = JSContext()
         return js_context.pack(data)
-
-
-config = DjangoBridgeConfig.from_settings()

--- a/python/django_bridge/response.py
+++ b/python/django_bridge/response.py
@@ -9,7 +9,7 @@ from django.templatetags.static import static
 from django.utils.cache import patch_cache_control
 from django.utils.html import conditional_escape
 
-from .conf import config as default_config
+from .conf import DjangoBridgeConfig
 from .metadata import Metadata
 
 
@@ -210,7 +210,7 @@ class CloseOverlayResponse(BaseResponse):
 
 def process_response(request, response, config=None):
     if config is None:
-        config = default_config
+        config = DjangoBridgeConfig.from_settings()
 
     if isinstance(response, StreamingHttpResponse):
         return response


### PR DESCRIPTION
Fixes #112

This PR makes it possible to use Django Bridge without adding to `INSTALLED_APPS` or putting it in `MIDDLEWARE_CLASSES`.

This is for [wagtail-reactadmin](https://github.com/kaedroho/wagtail-reactadmin) which is built using Django Bridge. Instead of adding django bridge to `INSTALLED_APPS`, you add `wagtail-reactadmin` instead and that'll generate the config required and pass it straight to `django_bridge.response.process_response`.

This also adds the ability to use a custom registry, which allows us to re-use Wagtail's own telepath registry.